### PR TITLE
Fix dev address error return

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1989,9 +1989,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 		CScript scriptPubKey = GetScriptForDestination(CBitcoinAddress(address).Get());
 		//scriptPubKey.SetDestination(address.Get());
 		if (block.vtx[0].vout[1].scriptPubKey != scriptPubKey)
-				return error("ConnectBlock() : coinbase does not pay to the dev address");
+                                return state.DoS(100, error("ConnectBlock(): coinbase does not pay to the dev fund address."), REJECT_INVALID, "bad-cb-dev-fee");
+
 		if (block.vtx[0].vout[1].nValue < GetDevCoin(blockReward))
-				return error("ConnectBlock() : coinbase does not pay enough to dev address");
+                                return state.DoS(100, error("ConnectBlock(): coinbase does not pay enough to the dev fund address."), REJECT_INVALID, "bad-cb-dev-fee");
 
 
     if(pindex->nHeight>=MINERHODLINGHEIGHT && pindex->nHeight<THEUNFORKENING){


### PR DESCRIPTION
return error() is not enough to clear the block from your chain. When a block is rejected for dev fund errors, you need to also call state.DoS so the block can be cleared. Without doing this, blocks can remain in memory and poison future blocks that come in.